### PR TITLE
plugin - update signature

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # serverless-plugin-upload-s3
-Serverless plugin to upload files to s3.
+Serverless plugin to upload files to s3. Requires at least `serverless@1.25.0`.
 
 
 ## Usage Example

--- a/upload-s3.js
+++ b/upload-s3.js
@@ -28,7 +28,7 @@ class UploadFiles {
         Bucket: file.s3Bucket,
         Key: file.fileName,
         Body: fs.createReadStream(file.localPath)
-      }, this.options.stage, this.region);
+      });
     }));
   }
 


### PR DESCRIPTION
*Untested*

`stage` and `region` are no longer needed as of [Serverless 1.25.0](https://github.com/serverless/serverless/releases/tag/v1.25.0) ([diff](https://github.com/serverless/serverless/commit/81c896bc127ed5a3d91277cafa7d8f53a45b3b27#diff-271ef5d492727880dcac1b94a86c878d)).

Technically a breaking change, since we're adding a version requirement.