### PR TITLE
feat: new command for only uploading files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,5 +23,17 @@ custom:
 
 The above example will result in `target/foo.jar` being uploaded to `s3://bucket1/foo.jar` and `docs/readme.md` uploaded to `s3://bucket2/bar-readme.md`.
 
+To only upload files to S3 without taking any other Serverless actions, you can run:
+
+```sh
+s3-upload upload --stage my-stage
+```
+
+E.g.
+
+```sh
+npm run sls -- s3-upload upload --stage my-stage
+```
+
 ## NoDeploy
 If the `--noDeploy` command-line option is specified, this plugin does not attempt to upload anything to S3.

--- a/upload-s3.js
+++ b/upload-s3.js
@@ -9,8 +9,22 @@ class UploadFiles {
     this.provider = serverless.getProvider('aws');
     this.region = this.serverless.service.provider.region;
 
+    this.commands = {
+      ['s3-upload']: {
+        usage: 'Upload files to S3',
+        lifecycleEvents: ['s3-upload'],
+        commands: {
+          upload: {
+            usage: 'Publish the files',
+            lifecycleEvents: ['upload']
+          }
+        }
+      }
+    };
+
     this.hooks = {
-      'deploy:deploy': () => this.uploadFiles()
+      'deploy:deploy': () => this.uploadFiles(),
+      's3-upload:upload:upload': () => this.uploadFiles(),
     };
   }
 


### PR DESCRIPTION
In some scenarios, users may only want to re-upload artifacts to S3 without applying any other Serverless changes. Thoughts on a new command to do this?

Quality notes:
* Functional:
  * Confirmed via CLI logs that file upload occurs when running `s3-upload upload`
* Performance:
  * N/A
* Security:
  * N/A
* Docs:
  * N/A 